### PR TITLE
Add Hour timer to Episode Porgress

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/anime/episode/EpisodeHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/anime/episode/EpisodeHolder.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.ui.anime.episode
 
 import android.text.SpannableStringBuilder
+import android.text.SpannedString
 import android.view.View
 import androidx.core.text.buildSpannedString
 import androidx.core.text.color
@@ -64,28 +65,57 @@ class EpisodeHolder(
             descriptions.add(Date(episode.date_upload).toRelativeString(itemView.context, adapter.relativeTime, adapter.dateFormat))
         }
         if (!episode.seen && episode.last_second_seen > 0) {
-            val lastPageRead = buildSpannedString {
-                color(adapter.readColor) {
-                    append(
-                        itemView.context.getString(
-                            R.string.episode_progress,
-                            String.format(
-                                "%d:%02d",
-                                TimeUnit.MILLISECONDS.toMinutes(episode.last_second_seen),
-                                TimeUnit.MILLISECONDS.toSeconds(episode.last_second_seen) -
-                                    TimeUnit.MINUTES.toSeconds(TimeUnit.MILLISECONDS.toMinutes(episode.last_second_seen))
-                            ),
-                            String.format(
-                                "%d:%02d",
-                                TimeUnit.MILLISECONDS.toMinutes(episode.total_seconds),
-                                TimeUnit.MILLISECONDS.toSeconds(episode.total_seconds) -
-                                    TimeUnit.MINUTES.toSeconds(TimeUnit.MILLISECONDS.toMinutes(episode.total_seconds))
+            val lastSecondSeen: SpannedString
+            if (episode.total_seconds > 3600000) {
+                lastSecondSeen = buildSpannedString {
+                    color(adapter.readColor) {
+                        append(
+                            itemView.context.getString(
+                                R.string.episode_progress,
+                                String.format(
+                                    "%d:%02d:%02d",
+                                    TimeUnit.MILLISECONDS.toHours(episode.last_second_seen),
+                                    TimeUnit.MILLISECONDS.toMinutes(episode.last_second_seen) -
+                                        TimeUnit.HOURS.toMinutes(TimeUnit.MILLISECONDS.toHours(episode.last_second_seen)),
+                                    TimeUnit.MILLISECONDS.toSeconds(episode.last_second_seen) -
+                                        TimeUnit.MINUTES.toSeconds(TimeUnit.MILLISECONDS.toMinutes(episode.last_second_seen))
+                                ),
+                                String.format(
+                                    "%d:%02d:%02d",
+                                    TimeUnit.MILLISECONDS.toHours(episode.total_seconds),
+                                    TimeUnit.MILLISECONDS.toMinutes(episode.total_seconds) -
+                                        TimeUnit.HOURS.toMinutes(TimeUnit.MILLISECONDS.toHours(episode.total_seconds)),
+                                    TimeUnit.MILLISECONDS.toSeconds(episode.total_seconds) -
+                                        TimeUnit.MINUTES.toSeconds(TimeUnit.MILLISECONDS.toMinutes(episode.total_seconds))
+                                )
                             )
                         )
-                    )
+                    }
+                }
+            } else {
+                lastSecondSeen = buildSpannedString {
+                    color(adapter.readColor) {
+                        append(
+                            itemView.context.getString(
+                                R.string.episode_progress,
+                                String.format(
+                                    "%d:%02d",
+                                    TimeUnit.MILLISECONDS.toMinutes(episode.last_second_seen),
+                                    TimeUnit.MILLISECONDS.toSeconds(episode.last_second_seen) -
+                                        TimeUnit.MINUTES.toSeconds(TimeUnit.MILLISECONDS.toMinutes(episode.last_second_seen))
+                                ),
+                                String.format(
+                                    "%d:%02d",
+                                    TimeUnit.MILLISECONDS.toMinutes(episode.total_seconds),
+                                    TimeUnit.MILLISECONDS.toSeconds(episode.total_seconds) -
+                                        TimeUnit.MINUTES.toSeconds(TimeUnit.MILLISECONDS.toMinutes(episode.total_seconds))
+                                )
+                            )
+                        )
+                    }
                 }
             }
-            descriptions.add(lastPageRead)
+            descriptions.add(lastSecondSeen)
         }
         if (!episode.scanlator.isNullOrBlank()) {
             descriptions.add(episode.scanlator!!)


### PR DESCRIPTION
A simple QOL to add an Hour part to the Episode Progress when it goes above 60 minutes

Example:-

![Screenshot_20220313-1317322](https://user-images.githubusercontent.com/36792807/158044869-53092c7e-f01f-4ad6-ab29-69185c12a099.png)
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  

  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
