### PR TITLE
add support to open torrent links in external players

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/ExternalIntents.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/ExternalIntents.kt
@@ -37,7 +37,7 @@ class ExternalIntents(val anime: Anime, val source: AnimeSource) {
         val pkgName = preferences.externalPlayerPreference()
         val anime = anime
         return if (pkgName.isNullOrEmpty()) {
-            if (videoUrl.toString().contains("magnet")) {
+            if (videoUrl.toString().contains("magnet") or videoUrl.toString().contains(".torrent")) {
                 torrentIntent(uri)
             } else {
                 Intent(Intent.ACTION_VIEW).apply {


### PR DESCRIPTION
added support for playing torrent in external players
Tested players:
- [Amnis](https://play.google.com/store/apps/details?id=com.amnis)
- [Torrent Player](https://play.google.com/store/apps/details?id=com.vit.torrentplayer)
- [xTorrent](https://play.google.com/store/apps/details?id=com.gamemalt.streamtorrentvideos)

[Video](https://drive.google.com/file/d/11nXM9p9drjz0PWBeh98bGgINJMoqiCTE/view)

extension example of https://subsplease.org/ using torrent:
https://drive.google.com/file/d/12VFPVoBhbXrZmnacU9-lxZ4Krxo2jIUV/view
Note: the option "Always use external player" is enable, otherwise it would open like in the first video