### PR TITLE
Add option to lock and unlock controls in mpv player

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/Gestures.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/Gestures.kt
@@ -44,6 +44,7 @@ class Gestures(
     }
 
     override fun onDoubleTap(e: MotionEvent): Boolean {
+        if (activity.isLocked) return false
         if (e.y < height * 0.05F || e.y > height * 0.95F) return false
         val interval = preferences.skipLengthPreference()
         when {
@@ -60,6 +61,7 @@ class Gestures(
         distanceX: Float,
         distanceY: Float
     ): Boolean {
+        if (activity.isLocked) return false
         if (e1.y < height * 0.05F || e1.y > height * 0.95F) return false
         val dx = e1.x - e2.x
         val dy = e1.y - e2.y

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -80,6 +80,8 @@ class PlayerActivity :
     private var width = 0
     private var height = 0
 
+    internal var isLocked = false
+
     private var audioFocusRestore: () -> Unit = {}
 
     private val audioFocusChangeListener = AudioManager.OnAudioFocusChangeListener { type ->
@@ -247,6 +249,12 @@ class PlayerActivity :
             gestures.onTouch(v, event)
             mDetector.onTouchEvent(event)
         }
+
+        // Lock and Unlock controls
+        binding.lockControls.setOnClickListener { isLocked = true; toggleControls() }
+        binding.unlockControls.setOnClickListener { isLocked = false; toggleControls() }
+
+        // Cycle, Long click controls
         binding.cycleAudioBtn.setOnLongClickListener { pickAudio(); true }
         binding.cycleSpeedBtn.setOnLongClickListener { pickSpeed(); true }
         binding.cycleSubsBtn.setOnLongClickListener { pickSub(); true }
@@ -271,7 +279,13 @@ class PlayerActivity :
     }
 
     fun toggleControls() {
-        binding.controls.isVisible = !binding.controls.isVisible
+        if (isLocked) {
+            binding.unlockControls.isVisible = !binding.unlockControls.isVisible
+            binding.controls.isVisible = false
+        } else {
+            binding.unlockControls.isVisible = false
+            binding.controls.isVisible = !binding.controls.isVisible
+        }
     }
 
     private fun pickAudio() {

--- a/app/src/main/res/layout/player_activity.xml
+++ b/app/src/main/res/layout/player_activity.xml
@@ -13,6 +13,16 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
+    <ImageButton
+        android:layout_marginHorizontal="5dp"
+        android:id="@+id/unlockControls"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:src="@drawable/ic_lock_open_24dp"
+        android:visibility="gone"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        app:tint="?attr/colorOnPrimarySurface" />
+
     <!-- This LinearLayout only exists to prevent clipping -->
     <LinearLayout
         android:layout_width="match_parent"
@@ -180,7 +190,15 @@
                 android:gravity="center"
                 android:orientation="horizontal">
 
-
+                <ImageButton
+                    android:layout_marginHorizontal="5dp"
+                    android:id="@+id/lockControls"
+                    android:layout_width="48dp"
+                    android:layout_height="match_parent"
+                    android:onClick="cycleAudio"
+                    android:src="@drawable/ic_lock_24dp"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    app:tint="?attr/colorOnPrimarySurface" />
 
                 <ImageButton
                     android:layout_marginHorizontal="5dp"


### PR DESCRIPTION
Changes
---
- Add lock and unlock icons to the player UI
- The unlock icon hides the usual player UI
- Double tap and Scroll Gestures return false when player is locked

Images
---

Unlocked player (bottom left)

![Screenshot_20220406-191012](https://user-images.githubusercontent.com/36792807/161959253-e4b70a3f-ab22-42f5-be3f-df3cf7de6c58.png)

Locked player (top left)

![Screenshot_20220406-191152](https://user-images.githubusercontent.com/36792807/161959243-57577307-7aa7-4997-91ad-436e7310bc84.png)

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
