### PR TITLE
Fix app closing on pressing back

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -809,9 +809,6 @@ class PlayerActivity :
             player.destroy()
         }
         abandonAudioFocus()
-        if (packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            finishAndRemoveTask()
-        }
         super.onDestroy()
     }
 
@@ -1129,8 +1126,10 @@ class PlayerActivity :
     private fun eventPropertyUi(property: String, value: Boolean) {
         when (property) {
             "pause" -> {
-                setAudioFocus(value)
-                updatePlaybackStatus(value)
+                if (!isFinishing) {
+                    setAudioFocus(value)
+                    updatePlaybackStatus(value)
+                }
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerControlsView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerControlsView.kt
@@ -67,8 +67,8 @@ class PlayerControlsView @JvmOverloads constructor(context: Context, attrs: Attr
                 PackageManager.FEATURE_PICTURE_IN_PICTURE,
             ) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
         }
-        binding.backArrowBtnLandscape.setOnClickListener { activity.finishAndRemoveTask() }
-        binding.backArrowBtnPortrait.setOnClickListener { activity.finishAndRemoveTask() }
+        binding.backArrowBtnLandscape.setOnClickListener { activity.onBackPressed() }
+        binding.backArrowBtnPortrait.setOnClickListener { activity.onBackPressed() }
 
         // Lock and Unlock controls
         binding.lockBtn.setOnClickListener { lockControls(true) }


### PR DESCRIPTION
Changes
---
- Fix a bug wherein the player tried to access an mpv property while destroyed, leading to the app closing completely

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
