### PR TITLE
Add option to disable double-tap seek

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/Gestures.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/Gestures.kt
@@ -32,8 +32,8 @@ class Gestures(
         if (activity.isLocked) return false
         val interval = preferences.skipLengthPreference()
         when {
-            e.x < width * 0.4F -> activity.doubleTapSeek(-interval, e)
-            e.x > width * 0.6F -> activity.doubleTapSeek(interval, e)
+            e.x < width * 0.4F && interval != 0 -> activity.doubleTapSeek(-interval, e)
+            e.x > width * 0.6F && interval != 0 -> activity.doubleTapSeek(interval, e)
             else -> activity.doubleTapPlayPause()
         }
         return true

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsPlayerController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsPlayerController.kt
@@ -56,12 +56,14 @@ class SettingsPlayerController : SettingsController() {
                 R.string.pref_skip_20,
                 R.string.pref_skip_10,
                 R.string.pref_skip_5,
+                R.string.pref_skip_disable,
             )
             entryValues = arrayOf(
                 "30",
                 "20",
                 "10",
                 "5",
+                "0",
             )
             defaultValue = "10"
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -442,6 +442,7 @@
     <string name="pref_skip_20">20s</string>
     <string name="pref_skip_10">10s</string>
     <string name="pref_skip_5">5s</string>
+    <string name="pref_skip_disable">Disable</string>
     <string name="pref_always_use_external_player">Always use external player</string>
     <string name="pref_player_fullscreen">Show content in display cutout</string>
     <string name="pref_pip_episode_toasts">Show episode toasts when switching episodes in PiP mode</string>


### PR DESCRIPTION
Added an option called Disable in "double-tap to skip length" where if you set it to disable it will not skip the video but instead play/pause the video regardless of where on the screen you double-tap.