### PR TITLE
External player fixes

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeController.kt
@@ -1028,12 +1028,14 @@ class AnimeController :
             } catch (e: Exception) {
                 return@launchIO makeErrorToast(activity, e)
             }
+            val downloadManager: AnimeDownloadManager = Injekt.get()
+            val isDownloaded = downloadManager.isEpisodeDownloaded(episode, presenter.anime, true)
             if (video != null) {
                 EXT_EPISODE = episode
                 EXT_ANIME = presenter.anime
 
                 val source = source ?: return@launchIO
-                val extIntent = ExternalIntents(presenter.anime, source).getExternalIntent(episode, video, activity)
+                val extIntent = ExternalIntents(presenter.anime, source).getExternalIntent(episode, video, isDownloaded, activity)
                 if (extIntent != null) try {
                     startActivityForResult(extIntent, REQUEST_EXTERNAL)
                 } catch (e: Exception) {
@@ -1505,7 +1507,6 @@ class AnimeController :
                     .forEach { logcat(LogPriority.WARN, it) }
             }
         }
-
 
         /**
          * Key to change the cover of a anime in [onActivityResult].

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeController.kt
@@ -1171,8 +1171,8 @@ class AnimeController :
         toolbar.findToolbarItem(R.id.action_mark_as_read)?.isVisible = episodes.any { !it.episode.seen }
         toolbar.findToolbarItem(R.id.action_mark_as_unread)?.isVisible = episodes.any { it.episode.seen }
         toolbar.findToolbarItem(R.id.action_mark_previous_as_read)?.isVisible = episodes.size == 1
-        toolbar.findToolbarItem(R.id.action_play_externally)?.isVisible = !preferences.alwaysUseExternalPlayer()
-        toolbar.findToolbarItem(R.id.action_play_internally)?.isVisible = preferences.alwaysUseExternalPlayer()
+        toolbar.findToolbarItem(R.id.action_play_externally)?.isVisible = !preferences.alwaysUseExternalPlayer() && episodes.size == 1
+        toolbar.findToolbarItem(R.id.action_play_internally)?.isVisible = preferences.alwaysUseExternalPlayer() && episodes.size == 1
     }
 
     override fun onActionItemClicked(mode: ActionMode, item: MenuItem): Boolean {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/ExternalIntents.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/ExternalIntents.kt
@@ -22,12 +22,12 @@ import java.io.File
 class ExternalIntents(val anime: Anime, val source: AnimeSource) {
     private val preferences: PreferencesHelper by injectLazy()
 
-    fun getExternalIntent(episode: Episode, video: Video, context: Context): Intent? {
+    fun getExternalIntent(episode: Episode, video: Video, isDownloaded: Boolean, context: Context): Intent? {
         val videoUrl = if (video.videoUrl == null) {
             makeErrorToast(context, Exception("video URL is null."))
             return null
         } else {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && isDownloaded) {
                 logcat { File(Uri.parse(video.videoUrl).path!!).path }
                 FileProvider.getUriForFile(
                     context,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recent/animehistory/AnimeHistoryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recent/animehistory/AnimeHistoryController.kt
@@ -53,7 +53,7 @@ class AnimeHistoryController : ComposeController<AnimeHistoryPresenter>(), RootC
             nestedScrollInterop = nestedScrollInterop,
             presenter = presenter,
             onClickCover = { history ->
-                router.pushController(AnimeController(history))
+                parentController!!.router.pushController(AnimeController(history))
             },
             onClickResume = { history ->
                 presenter.getNextEpisodeForAnime(history.animeId, history.episodeId)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recent/animehistory/AnimeHistoryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recent/animehistory/AnimeHistoryController.kt
@@ -1,28 +1,47 @@
 package eu.kanade.tachiyomi.ui.recent.animehistory
 
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import androidx.appcompat.widget.SearchView
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import eu.kanade.domain.episode.model.Episode
 import eu.kanade.presentation.animehistory.AnimeHistoryScreen
 import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.animesource.AnimeSourceManager
+import eu.kanade.tachiyomi.data.database.models.Anime
+import eu.kanade.tachiyomi.data.database.models.Episode
+import eu.kanade.tachiyomi.data.download.AnimeDownloadManager
+import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.ui.anime.AnimeController
+import eu.kanade.tachiyomi.ui.anime.episode.EpisodeItem
 import eu.kanade.tachiyomi.ui.base.controller.ComposeController
 import eu.kanade.tachiyomi.ui.base.controller.RootController
 import eu.kanade.tachiyomi.ui.base.controller.pushController
+import eu.kanade.tachiyomi.ui.player.EpisodeLoader
+import eu.kanade.tachiyomi.ui.player.ExternalIntents
 import eu.kanade.tachiyomi.ui.player.PlayerActivity
+import eu.kanade.tachiyomi.util.lang.awaitSingle
+import eu.kanade.tachiyomi.util.lang.launchIO
+import eu.kanade.tachiyomi.util.lang.launchUI
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import reactivecircus.flowbinding.appcompat.queryTextChanges
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import uy.kohesive.injekt.injectLazy
 
 class AnimeHistoryController : ComposeController<AnimeHistoryPresenter>(), RootController {
 
     private var query = ""
+
+    private val preferences: PreferencesHelper = Injekt.get()
+    private val sourceManager: AnimeSourceManager by injectLazy()
 
     override fun getTitle() = resources?.getString(R.string.label_recent_manga)
 
@@ -41,10 +60,10 @@ class AnimeHistoryController : ComposeController<AnimeHistoryPresenter>(), RootC
             },
             onClickDelete = { history, all ->
                 if (all) {
-                    // Reset last read of chapter to 0L
+                    // Reset last read of episode to 0L
                     presenter.removeAllFromHistory(history.animeId)
                 } else {
-                    // Remove all chapters belonging to manga from library
+                    // Remove all episodes belonging to anime from library
                     presenter.removeFromHistory(history)
                 }
             },
@@ -82,13 +101,80 @@ class AnimeHistoryController : ComposeController<AnimeHistoryPresenter>(), RootC
         }
     }
 
-    fun openEpisode(episode: Episode?) {
+    fun openEpisode(episode: Episode?, anime: Anime?) {
         val activity = activity ?: return
-        if (episode != null) {
-            val intent = PlayerActivity.newIntent(activity, episode.animeId, episode.id)
-            startActivity(intent)
+        if (episode != null && anime != null) {
+            val intent = PlayerActivity.newIntent(activity, anime, episode)
+
+            if (preferences.alwaysUseExternalPlayer()) launchIO {
+                val video = try {
+                    EpisodeLoader.getLink(episode, anime, source = sourceManager.getOrStub(anime.source)).awaitSingle()
+                } catch (e: Exception) {
+                    return@launchIO makeErrorToast(activity, e)
+                }
+                val downloadManager: AnimeDownloadManager = Injekt.get()
+                val isDownloaded = downloadManager.isEpisodeDownloaded(episode, anime, true)
+                if (video != null) {
+                    AnimeController.EXT_EPISODE = episode
+                    AnimeController.EXT_ANIME = anime
+
+                    val source = sourceManager.getOrStub(anime.source)
+                    val extIntent = ExternalIntents(anime, source).getExternalIntent(episode, video, isDownloaded, activity)
+                    if (extIntent != null) try {
+                        startActivityForResult(extIntent, AnimeController.REQUEST_EXTERNAL)
+                    } catch (e: Exception) {
+                        makeErrorToast(activity, e)
+                    }
+                } else {
+                    makeErrorToast(activity, Exception("Couldn't find any video links."))
+                }
+            } else {
+                startActivity(intent)
+            }
         } else {
-            activity.toast(R.string.no_next_chapter)
+            activity.toast(R.string.no_next_episode)
+        }
+    }
+
+    private fun makeErrorToast(context: Context, e: Exception?) {
+        launchUI { context.toast(e?.message ?: "Cannot open episode") }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        if (requestCode == AnimeController.REQUEST_EXTERNAL && resultCode == Activity.RESULT_OK) {
+            val anime = AnimeController.EXT_ANIME ?: return
+            val currentExtEpisode = AnimeController.EXT_EPISODE ?: return
+            val currentPosition: Long
+            val duration: Long
+            val cause = data!!.getStringExtra("end_by") ?: ""
+            if (cause.isNotEmpty()) {
+                val positionExtra = data.extras?.get("position")
+                currentPosition = if (positionExtra is Int) {
+                    positionExtra.toLong()
+                } else {
+                    positionExtra as? Long ?: 0L
+                }
+                val durationExtra = data.extras?.get("duration")
+                duration = if (durationExtra is Int) {
+                    durationExtra.toLong()
+                } else {
+                    durationExtra as? Long ?: 0L
+                }
+            } else {
+                if (data.extras?.get("extra_position") != null) {
+                    currentPosition = data.getLongExtra("extra_position", 0L)
+                    duration = data.getLongExtra("extra_duration", 0L)
+                } else {
+                    currentPosition = data.getIntExtra("position", 0).toLong()
+                    duration = data.getIntExtra("duration", 0).toLong()
+                }
+            }
+            if (cause == "playback_completion") {
+                AnimeController.setEpisodeProgress(currentExtEpisode, anime, currentExtEpisode.total_seconds, currentExtEpisode.total_seconds)
+            } else {
+                AnimeController.setEpisodeProgress(currentExtEpisode, anime, currentPosition, duration)
+            }
+            AnimeController.saveEpisodeHistory(EpisodeItem(currentExtEpisode, anime))
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recent/animehistory/AnimeHistoryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recent/animehistory/AnimeHistoryPresenter.kt
@@ -13,6 +13,7 @@ import eu.kanade.domain.animehistory.interactor.RemoveAnimeHistoryById
 import eu.kanade.domain.animehistory.model.AnimeHistoryWithRelations
 import eu.kanade.presentation.animehistory.HistoryUiModel
 import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.data.database.AnimeDatabaseHelper
 import eu.kanade.tachiyomi.ui.base.presenter.BasePresenter
 import eu.kanade.tachiyomi.util.lang.launchIO
 import eu.kanade.tachiyomi.util.lang.launchUI
@@ -27,6 +28,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.map
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import uy.kohesive.injekt.injectLazy
 import java.util.Date
 
 /**
@@ -99,11 +101,13 @@ class AnimeHistoryPresenter(
         }
     }
 
-    fun getNextEpisodeForAnime(mangaId: Long, chapterId: Long) {
+    fun getNextEpisodeForAnime(animeId: Long, episodeId: Long) {
         presenterScope.launchIO {
-            val episode = getNextEpisodeForAnime.await(mangaId, chapterId)
+            val db: AnimeDatabaseHelper by injectLazy()
+            val episode = db.getEpisode(getNextEpisodeForAnime.await(animeId, episodeId)!!.id).executeAsBlocking()
+            val anime = db.getAnime(animeId).executeAsBlocking()
             launchUI {
-                view?.openEpisode(episode)
+                view?.openEpisode(episode, anime)
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recent/animeupdates/AnimeUpdatesController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recent/animeupdates/AnimeUpdatesController.kt
@@ -470,8 +470,8 @@ class AnimeUpdatesController :
         toolbar.findToolbarItem(R.id.action_remove_bookmark)?.isVisible = episodes.all { it.bookmark }
         toolbar.findToolbarItem(R.id.action_mark_as_seen)?.isVisible = episodes.any { !it.episode.seen }
         toolbar.findToolbarItem(R.id.action_mark_as_unseen)?.isVisible = episodes.all { it.episode.seen }
-        toolbar.findToolbarItem(R.id.action_play_externally)?.isVisible = !preferences.alwaysUseExternalPlayer()
-        toolbar.findToolbarItem(R.id.action_play_internally)?.isVisible = preferences.alwaysUseExternalPlayer()
+        toolbar.findToolbarItem(R.id.action_play_externally)?.isVisible = !preferences.alwaysUseExternalPlayer() && episodes.size == 1
+        toolbar.findToolbarItem(R.id.action_play_internally)?.isVisible = preferences.alwaysUseExternalPlayer() && episodes.size == 1
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recent/history/HistoryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recent/history/HistoryController.kt
@@ -34,7 +34,7 @@ class HistoryController : ComposeController<HistoryPresenter>(), RootController 
             nestedScrollInterop = nestedScrollInterop,
             presenter = presenter,
             onClickCover = { history ->
-                router.pushController(MangaController(history))
+                parentController!!.router.pushController(MangaController(history))
             },
             onClickResume = { history ->
                 presenter.getNextChapterForManga(history.mangaId, history.chapterId)

--- a/app/src/main/res/menu/updates_episode_selection.xml
+++ b/app/src/main/res/menu/updates_episode_selection.xml
@@ -51,4 +51,20 @@
         app:showAsAction="always"
         tools:ignore="AlwaysShowAction" />
 
+    <item
+        android:id="@+id/action_play_externally"
+        android:icon="@drawable/ic_baseline_open_in_new_24"
+        android:title="@string/action_play_externally"
+        app:iconTint="?attr/colorOnSurface"
+        app:showAsAction="always"
+        tools:ignore="AlwaysShowAction" />
+
+    <item
+        android:id="@+id/action_play_internally"
+        android:icon="@drawable/ic_baseline_input_24"
+        android:title="@string/action_play_internally"
+        app:iconTint="?attr/colorOnSurface"
+        app:showAsAction="always"
+        tools:ignore="AlwaysShowAction" />
+
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -939,6 +939,7 @@
     <string name="information_no_downloads">No downloads</string>
     <string name="information_no_recent">No recent updates</string>
     <string name="information_no_recent_manga">Nothing read recently</string>
+    <string name="information_no_recent_anime">Nothing watched recently</string>
     <string name="information_empty_library">Your library is empty</string>
     <string name="getting_started_guide">Getting started guide</string>
     <string name="information_empty_category">You have no categories. Tap the plus button to create one for organizing your library.</string>


### PR DESCRIPTION
Changes
---
- Fix non - downloaded episodes not being parsed properly when sent to external players
- Add external player override to
    - Updates
    - History
- Added change player option to Updates
- Option to change player now hides when selecting multiple episodes in
    - Library
    - Updates
- Fix a bug with accessing manga and anime from History , by closing the parent Tab Controller
