### PR TITLE
Few QOLs and bug fixes

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -13,8 +13,6 @@ object PreferenceKeys {
 
     const val pipEpisodeToasts = "pref_pip_episode_toasts"
 
-    const val autoplayEnabled = "pref_auto_play_enabled"
-
     const val mpvConf = "pref_mpv_conf"
 
     const val defaultOrientationType = "pref_default_orientation_type_key"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -121,7 +121,9 @@ class PreferencesHelper(val context: Context) {
 
     fun pipEpisodeToasts() = prefs.getBoolean(Keys.pipEpisodeToasts, true)
 
-    fun autoplayEnabled() = flowPrefs.getBoolean(Keys.autoplayEnabled, false)
+    fun autoplayEnabled() = flowPrefs.getBoolean("pref_auto_play_enabled", false)
+
+    fun invertedPlaybackTxt() = flowPrefs.getBoolean("pref_invert_playback_txt", false)
 
     fun mpvConf() = prefs.getString(Keys.mpvConf, "")
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -546,17 +546,30 @@ class PlayerActivity :
             2 -> {
                 MPVLib.setOptionString("video-aspect-override", "-1")
                 MPVLib.setOptionString("panscan", "1.0")
+
+                playerControls.binding.playerInformation.text = getString(R.string.video_fit_height)
             }
             1 -> {
                 MPVLib.setOptionString("video-aspect-override", "-1")
                 MPVLib.setOptionString("panscan", "0.0")
+
+                playerControls.binding.playerInformation.text = getString(R.string.video_fit_width)
             }
             0 -> {
                 val newAspect = "$width/$height"
                 MPVLib.setOptionString("video-aspect-override", newAspect)
                 MPVLib.setOptionString("panscan", "0.0")
+
+                playerControls.binding.playerInformation.text = getString(R.string.video_fill_width_and_height)
             }
         }
+        if (playerViewMode != preferences.getPlayerViewMode()) {
+            animationHandler.removeCallbacks(playerInformationRunnable)
+            playerControls.binding.playerInformation.visibility = View.VISIBLE
+            animationHandler.postDelayed(playerInformationRunnable, 1000L)
+        }
+
+        preferences.setPlayerViewMode(playerViewMode)
     }
 
     @Suppress("DEPRECATION")
@@ -758,7 +771,6 @@ class PlayerActivity :
             2 -> 0
             else -> 0
         }
-        preferences.setPlayerViewMode(playerViewMode)
         setViewMode()
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -1218,6 +1218,8 @@ class PlayerActivity :
         }
     }
 
+    private val nextEpisodeRunnable = Runnable { switchEpisode(false) }
+
     @Suppress("DEPRECATION")
     private fun eventPropertyUi(property: String, value: Boolean) {
         when (property) {
@@ -1226,10 +1228,11 @@ class PlayerActivity :
                     setAudioFocus(value)
 
                     if (player.timePos != null && player.duration != null) {
+                        animationHandler.removeCallbacks(nextEpisodeRunnable)
                         val isVideoEof = MPVLib.getPropertyBoolean("eof-reached") == true
                         val isVideoCompleted = isVideoEof || (player.timePos!! >= player.duration!!)
                         if (isVideoCompleted && preferences.autoplayEnabled().get()) {
-                            animationHandler.postDelayed({ switchEpisode(false) }, 1000L)
+                            animationHandler.postDelayed(nextEpisodeRunnable, 1000L)
                         }
                     }
                     updatePlaybackStatus(value)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -470,7 +470,7 @@ class PlayerActivity :
 
         when {
             epTxt == "Invalid" -> return
-            epTxt == null -> { launchUI { toast(errorRes) }; showLoadingIndicator(false) }
+            epTxt == null -> { if (presenter.anime != null) launchUI { toast(errorRes) }; showLoadingIndicator(false) }
             isInPipMode -> if (preferences.pipEpisodeToasts()) launchUI { toast(epTxt) }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -929,6 +929,7 @@ class PlayerActivity :
     override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: Configuration) {
         isInPipMode = isInPictureInPictureMode
         isPipStarted = isInPipMode
+        playerControls.lockControls(isInPipMode)
         super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
 
         if (isInPictureInPictureMode) {
@@ -971,6 +972,7 @@ class PlayerActivity :
     fun startPiP(view: View) {
         if (packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             isPipStarted = true
+            playerControls.hideControls(true)
             player.paused?.let { updatePictureInPictureActions(!it) }
                 ?.let { this.enterPictureInPictureMode(it) }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -548,20 +548,20 @@ class PlayerActivity :
                 MPVLib.setOptionString("video-aspect-override", "-1")
                 MPVLib.setOptionString("panscan", "1.0")
 
-                playerControls.binding.playerInformation.text = getString(R.string.video_fit_height)
+                playerControls.binding.playerInformation.text = getString(R.string.video_crop_screen)
             }
             1 -> {
                 MPVLib.setOptionString("video-aspect-override", "-1")
                 MPVLib.setOptionString("panscan", "0.0")
 
-                playerControls.binding.playerInformation.text = getString(R.string.video_fit_width)
+                playerControls.binding.playerInformation.text = getString(R.string.video_fit_screen)
             }
             0 -> {
                 val newAspect = "$width/$height"
                 MPVLib.setOptionString("video-aspect-override", newAspect)
                 MPVLib.setOptionString("panscan", "0.0")
 
-                playerControls.binding.playerInformation.text = getString(R.string.video_fill_width_and_height)
+                playerControls.binding.playerInformation.text = getString(R.string.video_stretch_screen)
             }
         }
         if (playerViewMode != preferences.getPlayerViewMode()) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -55,6 +55,7 @@ import eu.kanade.tachiyomi.ui.base.activity.BaseRxActivity
 import eu.kanade.tachiyomi.util.lang.launchUI
 import eu.kanade.tachiyomi.util.system.LocaleHelper
 import eu.kanade.tachiyomi.util.system.logcat
+import eu.kanade.tachiyomi.util.system.powerManager
 import eu.kanade.tachiyomi.util.system.toast
 import `is`.xyz.mpv.MPVLib
 import `is`.xyz.mpv.Utils
@@ -910,7 +911,11 @@ class PlayerActivity :
             presenter.saveEpisodeProgress(player.timePos, player.duration)
             player.paused = true
         }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && isInPipMode) finishAndRemoveTask()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+            isInPipMode &&
+            powerManager.isInteractive
+        ) finishAndRemoveTask()
+
         super.onStop()
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerControlsView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerControlsView.kt
@@ -103,7 +103,7 @@ class PlayerControlsView @JvmOverloads constructor(context: Context, attrs: Attr
         }
     }
 
-    private fun lockControls(locked: Boolean) {
+    internal fun lockControls(locked: Boolean) {
         activity.isLocked = locked
         toggleControls()
     }
@@ -134,8 +134,10 @@ class PlayerControlsView @JvmOverloads constructor(context: Context, attrs: Attr
 
     internal fun hideControls(hide: Boolean) {
         animationHandler.removeCallbacks(controlsViewRunnable)
-        if (hide) binding.controlsView.isVisible = false
-        else showAndFadeControls()
+        if (hide) {
+            binding.controlsView.isVisible = false
+            binding.lockedView.isVisible = false
+        } else showAndFadeControls()
     }
 
     @SuppressLint("SetTextI18n")

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerControlsView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerControlsView.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.ui.player
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.ContextWrapper
 import android.os.Build
@@ -81,6 +82,11 @@ class PlayerControlsView @JvmOverloads constructor(context: Context, attrs: Attr
         binding.nextBtn.setOnClickListener { activity.switchEpisode(false) }
         binding.prevBtn.setOnClickListener { activity.switchEpisode(true) }
 
+        binding.playbackPositionBtn.setOnClickListener {
+            preferences.invertedPlaybackTxt().set(!preferences.invertedPlaybackTxt().get())
+            if (activity.player.timePos != null) updatePlaybackPos(activity.player.timePos!!)
+        }
+
         binding.toggleAutoplay.setOnCheckedChangeListener { _, isChecked ->
             activity.toggleAutoplay(isChecked)
         }
@@ -132,8 +138,12 @@ class PlayerControlsView @JvmOverloads constructor(context: Context, attrs: Attr
         else showAndFadeControls()
     }
 
+    @SuppressLint("SetTextI18n")
     internal fun updatePlaybackPos(position: Int) {
-        binding.playbackPositionTxt.text = Utils.prettyTime(position)
+        if (preferences.invertedPlaybackTxt().get() && activity.player.duration != null) {
+            binding.playbackPositionTxt.text = "-${ Utils.prettyTime(activity.player.duration!! - position) }"
+        } else binding.playbackPositionTxt.text = Utils.prettyTime(position)
+
         if (!userIsOperatingSeekbar) {
             binding.playbackSeekbar.progress = position
         }

--- a/app/src/main/res/layout/player_controls.xml
+++ b/app/src/main/res/layout/player_controls.xml
@@ -256,6 +256,16 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintLeft_toLeftOf="parent" />
 
+        <Button
+            android:id="@+id/playbackPositionBtn"
+            android:layout_width="96dp"
+            android:layout_height="48dp"
+            android:layout_marginLeft="10dp"
+            android:layout_marginBottom="10dp"
+            android:background="?attr/selectableItemBackground"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent" />
+
         <SeekBar
             android:id="@+id/playbackSeekbar"
             android:layout_width="0dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -997,7 +997,9 @@
     <string name="player_overlay_back">Back</string>
     <string name="enable_auto_play">"Auto-play is on"</string>
     <string name="disable_auto_play">"Auto-play is off"</string>
-
+    <string name="video_fit_height">"Fit width"</string>
+    <string name="video_fit_width">"Fit height"</string>
+    <string name="video_fill_width_and_height">"Fill width and height"</string>
     <!-- Aniyomi stuff -->
     <string name="playback_speed_dialog_title">Change playback speed:</string>
     <string name="playback_speed_dialog_reset">Reset</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -997,9 +997,9 @@
     <string name="player_overlay_back">Back</string>
     <string name="enable_auto_play">"Auto-play is on"</string>
     <string name="disable_auto_play">"Auto-play is off"</string>
-    <string name="video_fit_height">"Fit width"</string>
-    <string name="video_fit_width">"Fit height"</string>
-    <string name="video_fill_width_and_height">"Fill width and height"</string>
+    <string name="video_fit_screen">"Fit to screen"</string>
+    <string name="video_crop_screen">"Cropped to screen"</string>
+    <string name="video_stretch_screen">"Stretched to screen"</string>
     <!-- Aniyomi stuff -->
     <string name="playback_speed_dialog_title">Change playback speed:</string>
     <string name="playback_speed_dialog_reset">Reset</string>


### PR DESCRIPTION
Changes
---

- Added option to invert the time shown in the playback position text
- Add strings that show up as player information when changing the view mode of the player
- Fixed auto-play moving too fast and sometimes skipping unseen episodes
- Fixed a few more bugs regarding PiP
     - PiP now doesn't close when the device's screen is switched off
     - Locks and hides controls immediately upon pressing the button to prevent misinputs and UI errors
     - Fixed "No ___ Episode" toasts randomly showing up when changing episodes
     
Images
---

Inverted playback position text :

![Screenshot_20220526-191720-066](https://user-images.githubusercontent.com/36792807/170469930-7bc3624e-3520-4845-9261-b2bcb2b08690.png)

Different view mode strings :

| Fit | Crop | Stretch |
| ------- | ------- | ------- |
| ![Screenshot_20220526-191724](https://user-images.githubusercontent.com/36792807/170470331-266350f0-c529-44fa-a6f0-584df64490b1.png) | ![Screenshot_20220526-191729](https://user-images.githubusercontent.com/36792807/170470373-ac550ffa-d7b1-4726-be91-32f98a579e1b.png) | ![Screenshot_20220526-191736](https://user-images.githubusercontent.com/36792807/170470408-b0a272cc-51ef-49eb-a63f-ba556285535e.png) |



