### PR TITLE
Player UI hidden on player startup

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -298,7 +298,6 @@ class PlayerActivity :
 
         setVisibilities()
 
-        playerControls.showAndFadeControls()
         playerControls.hideControls(true)
         toggleAutoplay(preferences.autoplayEnabled().get())
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -299,6 +299,7 @@ class PlayerActivity :
         setVisibilities()
 
         playerControls.showAndFadeControls()
+        playerControls.hideControls(true)
         toggleAutoplay(preferences.autoplayEnabled().get())
 
         setMpvConf()


### PR DESCRIPTION
I would like this simple thing in the player that player UI will be hidden from the start of the player.
I tested a few scenarios, seem fine.
I am not sure if hideControls() is in right place though, tell me if I have to move it up or down.
