### PR TITLE
Fix for external players lastSeenPosition problem

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/ExternalIntents.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/ExternalIntents.kt
@@ -87,7 +87,7 @@ class ExternalIntents(val anime: Anime, val source: AnimeSource) {
                     preferences.preserveWatchingPosition() &&
                         episode.lastSecondSeen == episode.totalSeconds
                     )
-            ) 0L else episode.lastSecondSeen
+            ) 1L else episode.lastSecondSeen
         } else episode.lastSecondSeen
 
         return if (pkgName.isNullOrEmpty()) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsPlayerController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsPlayerController.kt
@@ -207,7 +207,7 @@ class SettingsPlayerController : SettingsController() {
                 switchPreference {
                     key = Keys.pipOnExit
                     titleRes = R.string.pref_pip_on_exit
-                    defaultValue = true
+                    defaultValue = false
                 }
             }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -427,7 +427,7 @@
     <string name="rotation_type">Rotation type</string>
     <string name="rotation_free">Free</string>
     <string name="rotation_portrait">Portrait</string>
-    <string name="rotation_reverse_portrait">Reverse portrait</string>
+    <string name="rotation_reverse_portrait">Reverse Portrait</string>
     <string name="rotation_landscape">Landscape</string>
     <string name="rotation_reverse_landscape">Reverse Landscape</string>
     <string name="rotation_sensor_portrait">Sensor Portrait</string>
@@ -482,8 +482,8 @@
     <string name="pref_skip_10">10s</string>
     <string name="pref_skip_5">5s</string>
     <string name="pref_skip_disable">Disable</string>
-    <string name="pref_player_smooth_seek">Enable smoother seeking</string>
-    <string name="pref_player_smooth_seek_summary">When disabled, seeking will focus on keyframes, leading to faster but less precise seeking</string>
+    <string name="pref_player_smooth_seek">Enable precise seeking</string>
+    <string name="pref_player_smooth_seek_summary">When enabled, seeking will not focus on keyframes, leading to slower but precise seeking</string>
     <string name="pref_player_fullscreen">Show content in display cutout</string>
     <string name="pref_player_hide_controls">Hide player controls when opening the player</string>
     <string name="pref_pip_episode_toasts">Show episode toasts when switching episodes in PiP mode</string>


### PR DESCRIPTION
* Mainly fixes the problem with external players not playing well with the last seen position for seen episodes. When it's 0L the external apps don't seem to register it and end up using their internal systems. Credit: @Quickdesh
* On older devices where PiP is not supported back button was not working so right now making pipOnExit off by default till it's fixed.
* Changed two strings