### PR TITLE
Option to either invert elapsed time or total time with remaining time

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -134,7 +134,7 @@ class PreferencesHelper(val context: Context) {
     fun autoplayEnabled() = flowPrefs.getBoolean("pref_auto_play_enabled", false)
 
     fun invertedPlaybackTxt() = flowPrefs.getBoolean("pref_invert_playback_txt", false)
-    
+
     fun invertedDurationTxt() = flowPrefs.getBoolean("pref_invert_duration_txt", false)
 
     fun mpvConf() = prefs.getString(Keys.mpvConf, "")

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -134,6 +134,8 @@ class PreferencesHelper(val context: Context) {
     fun autoplayEnabled() = flowPrefs.getBoolean("pref_auto_play_enabled", false)
 
     fun invertedPlaybackTxt() = flowPrefs.getBoolean("pref_invert_playback_txt", false)
+    
+    fun invertedDurationTxt() = flowPrefs.getBoolean("pref_invert_duration_txt", false)
 
     fun mpvConf() = prefs.getString(Keys.mpvConf, "")
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -1436,7 +1436,10 @@ class PlayerActivity :
     private fun eventPropertyUi(property: String, value: Long) {
         when (property) {
             "demuxer-cache-time" -> playerControls.updateBufferPosition(value.toInt())
-            "time-pos" -> playerControls.updatePlaybackPos(value.toInt())
+            "time-pos" -> {
+                playerControls.updatePlaybackPos(value.toInt())
+                if (preferences.invertedDurationTxt().get()) playerControls.updatePlaybackDuration(value.toInt())
+            }
             "duration" -> playerControls.updatePlaybackDuration(value.toInt())
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerControlsView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerControlsView.kt
@@ -158,7 +158,7 @@ class PlayerControlsView @JvmOverloads constructor(context: Context, attrs: Attr
 
         binding.playbackPositionBtn.setOnClickListener {
             preferences.invertedDurationTxt().set(false)
-            if (activity.player.timePos != null) updatePlaybackPos(activity.player.timePos!!)
+            preferences.invertedPlaybackTxt().set(!preferences.invertedPlaybackTxt().get())
             if (activity.player.timePos != null) {
                 updatePlaybackPos(activity.player.timePos!!)
                 updatePlaybackDuration(activity.player.duration!!)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerControlsView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerControlsView.kt
@@ -243,7 +243,7 @@ class PlayerControlsView @JvmOverloads constructor(context: Context, attrs: Attr
         if (preferences.invertedDurationTxt().get() && activity.player.duration != null) {
             binding.playbackDurationTxt.text = "-${ Utils.prettyTime(activity.player.duration!! - duration) }"
         } else binding.playbackDurationTxt.text = Utils.prettyTime(duration)
-        
+
         if (!userIsOperatingSeekbar) {
             binding.playbackSeekbar.max = activity.player.duration!!
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerControlsView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerControlsView.kt
@@ -157,8 +157,21 @@ class PlayerControlsView @JvmOverloads constructor(context: Context, attrs: Attr
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
 
         binding.playbackPositionBtn.setOnClickListener {
-            preferences.invertedPlaybackTxt().set(!preferences.invertedPlaybackTxt().get())
+            preferences.invertedDurationTxt().set(false)
             if (activity.player.timePos != null) updatePlaybackPos(activity.player.timePos!!)
+            if (activity.player.timePos != null) {
+                updatePlaybackPos(activity.player.timePos!!)
+                updatePlaybackDuration(activity.player.duration!!)
+            }
+        }
+
+        binding.playbackDurationBtn.setOnClickListener {
+            preferences.invertedPlaybackTxt().set(false)
+            preferences.invertedDurationTxt().set(!preferences.invertedDurationTxt().get())
+            if (preferences.invertedDurationTxt().get() && activity.player.timePos != null) {
+                updatePlaybackPos(activity.player.timePos!!)
+                updatePlaybackDuration(activity.player.timePos!!)
+            } else updatePlaybackDuration(activity.player.duration!!)
         }
 
         binding.toggleAutoplay.setOnCheckedChangeListener { _, isChecked ->
@@ -225,10 +238,14 @@ class PlayerControlsView @JvmOverloads constructor(context: Context, attrs: Attr
         updateSpeedButton()
     }
 
+    @SuppressLint("SetTextI18n")
     internal fun updatePlaybackDuration(duration: Int) {
-        binding.playbackDurationTxt.text = Utils.prettyTime(duration)
+        if (preferences.invertedDurationTxt().get() && activity.player.duration != null) {
+            binding.playbackDurationTxt.text = "-${ Utils.prettyTime(activity.player.duration!! - duration) }"
+        } else binding.playbackDurationTxt.text = Utils.prettyTime(duration)
+        
         if (!userIsOperatingSeekbar) {
-            binding.playbackSeekbar.max = duration
+            binding.playbackSeekbar.max = activity.player.duration!!
         }
     }
 

--- a/app/src/main/res/layout/player_controls.xml
+++ b/app/src/main/res/layout/player_controls.xml
@@ -392,6 +392,14 @@
                 android:textColor="@android:color/white"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintRight_toRightOf="parent" />
+            
+            <Button
+                android:id="@+id/playbackDurationBtn"
+                android:layout_width="96dp"
+                android:layout_height="48dp"
+                android:background="?attr/selectableItemBackground"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintRight_toRightOf="parent" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </RelativeLayout>


### PR DESCRIPTION
Before this PR there were two options:
* Elapsed time & Total time
* Remaining time & Total time

Now there is another option:
* Elapsed time & Remaining time

I have made it so that only one of these configurations will be displayed at a time. So before you could switch between `Elapsed time & Total time` & `Remaining time & Total time` now you can switch between `Elapsed time & Total time`, `Remaining time & Total time` or `Elapsed time & Remaining time`.

If you think it will be good to have this feature then please merge this PR.