### PR TITLE
Fix progress saving properly

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -470,16 +470,12 @@ class PlayerActivity :
      */
     internal fun switchEpisode(previous: Boolean, autoPlay: Boolean = false) {
         val switchMethod = if (previous && !autoPlay) {
-            { callback: () -> Unit -> presenter.previousEpisode(callback) }
+            { callback: () -> Unit -> presenter.previousEpisode(player.timePos, player.duration, callback) }
         } else {
-            { callback: () -> Unit -> presenter.nextEpisode(callback, autoPlay) }
+            { callback: () -> Unit -> presenter.nextEpisode(player.timePos, player.duration, callback, autoPlay) }
         }
         val errorRes = if (previous) R.string.no_previous_episode else R.string.no_next_episode
 
-        launchIO {
-            presenter.saveEpisodeProgress(player.timePos, player.duration)
-            presenter.saveEpisodeHistory()
-        }
         val wasPlayerPaused = player.paused
         player.paused = true
         showLoadingIndicator(true)


### PR DESCRIPTION
First things first, I wrote code that just made sense to me. It works, but I don't believe it is the most efficient way to go about it. So Jmir, it would be helpful if you could go through the code and point out/fix stuff that could work better

The problem is that when saving progress it searches for a global ***currentEpisode***, but sometimes the ***currentEpisode*** changes by the time it can update leading to problems when moving forward or back in episodes.

This code is a simple workaround to it!

Changes
---
- Episode progress now updates within the next and previous episode functions
- Said functions now accept position and duration to pass on to progress
- Episode progress also accepts the current episode prior to it being updated