### PR TITLE
Fixes the bug where player will crash while trying to invert time while video is not loaded

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -1455,7 +1455,7 @@ class PlayerActivity :
                 playerControls.updatePlaybackPos(value.toInt())
                 if (preferences.invertedDurationTxt().get()) playerControls.updatePlaybackDuration(value.toInt())
             }
-            "duration" -> playerControls.updatePlaybackDuration(value.toInt())
+            "duration" -> if (!preferences.invertedDurationTxt().get()) playerControls.updatePlaybackDuration(value.toInt())
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerControlsView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerControlsView.kt
@@ -158,22 +158,25 @@ class PlayerControlsView @JvmOverloads constructor(context: Context, attrs: Attr
         binding.pipBtn.setOnClickListener { activity.startPiP() }
 
         binding.pipBtn.isVisible = !preferences.pipOnExit() && activity.deviceSupportsPip
+        
         binding.playbackPositionBtn.setOnClickListener {
-            preferences.invertedDurationTxt().set(false)
-            preferences.invertedPlaybackTxt().set(!preferences.invertedPlaybackTxt().get())
-            if (activity.player.timePos != null) {
+            if (activity.player.timePos != null && activity.player.duration != null) {
+                preferences.invertedDurationTxt().set(false)
+                preferences.invertedPlaybackTxt().set(!preferences.invertedPlaybackTxt().get())
                 updatePlaybackPos(activity.player.timePos!!)
                 updatePlaybackDuration(activity.player.duration!!)
             }
         }
 
         binding.playbackDurationBtn.setOnClickListener {
-            preferences.invertedPlaybackTxt().set(false)
-            preferences.invertedDurationTxt().set(!preferences.invertedDurationTxt().get())
-            if (preferences.invertedDurationTxt().get() && activity.player.timePos != null) {
-                updatePlaybackPos(activity.player.timePos!!)
-                updatePlaybackDuration(activity.player.timePos!!)
-            } else updatePlaybackDuration(activity.player.duration!!)
+            if (activity.player.timePos != null && activity.player.duration != null) {
+                preferences.invertedPlaybackTxt().set(false)
+                preferences.invertedDurationTxt().set(!preferences.invertedDurationTxt().get())
+                if (preferences.invertedDurationTxt().get()) {
+                    updatePlaybackPos(activity.player.timePos!!)
+                    updatePlaybackDuration(activity.player.timePos!!)
+                } else updatePlaybackDuration(activity.player.duration!!)
+            }
         }
 
         binding.toggleAutoplay.setOnCheckedChangeListener { _, isChecked ->


### PR DESCRIPTION
* Now playbackPositionBtn and playbackDurationBtn won't work if the player has not loaded the current time and total time, before this the player would crash after clicking playbackDurationBtn because it was not checking if the duration is null or not.
* One small fix where if playback duration time was inverted it will show -00:00 until 1 second is passed and then it will show correctly. Now it shows the correct inverted value at the start of the video. credit: @Quickdesh