### PR TITLE
added support for ADM 

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/AnimeDownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/AnimeDownloadManager.kt
@@ -169,6 +169,7 @@ class AnimeDownloadManager(
     fun downloadEpisodesAlt(anime: Anime, episodes: List<Episode>, autoStart: Boolean = true) {
         downloader.queueEpisodes(anime, episodes, autoStart, true)
     }
+
     /**
      * Builds the page list of a downloaded episode.
      *

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/AnimeDownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/AnimeDownloadManager.kt
@@ -169,7 +169,6 @@ class AnimeDownloadManager(
     fun downloadEpisodesAlt(anime: Anime, episodes: List<Episode>, autoStart: Boolean = true) {
         downloader.queueEpisodes(anime, episodes, autoStart, true)
     }
-
     /**
      * Builds the page list of a downloaded episode.
      *

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/AnimeDownloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/AnimeDownloader.kt
@@ -629,7 +629,12 @@ class AnimeDownloader(
                                 putExtra("com.dv.get.ACTION_LIST_ADD", "${Uri.parse(video.videoUrl)}<info>$filename.mp4")
                                 putExtra("com.dv.get.ACTION_LIST_PATH", tmpDir.filePath!!.substringBeforeLast("_"))
                             }
-                            video.progress = 1
+                            it.delete()
+                            tmpDir.delete()
+                            queue.forEach { Anime ->
+                                Anime.status = AnimeDownload.State.DOWNLOADED
+                                completeAnimeDownload(Anime)
+                            }
                         }
                     }
                 } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/AnimeDownloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/AnimeDownloader.kt
@@ -623,13 +623,13 @@ class AnimeDownloader(
                             }
                         }
                         pkgName.startsWith("com.dv.adm") -> {
-                            it.delete()
                             intent.apply {
                                 component = ComponentName(pkgName, "$pkgName.AEditor")
                                 action = Intent.ACTION_VIEW
                                 putExtra("com.dv.get.ACTION_LIST_ADD", "${Uri.parse(video.videoUrl)}<info>$filename.mp4")
                                 putExtra("com.dv.get.ACTION_LIST_PATH", tmpDir.filePath!!.substringBeforeLast("_"))
                             }
+                            video.progress = 1
                         }
                     }
                 } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/AnimeDownloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/AnimeDownloader.kt
@@ -631,7 +631,7 @@ class AnimeDownloader(
                             }
                             it.delete()
                             tmpDir.delete()
-                            queue.forEach { Anime ->
+                            queue.find { Anime -> Anime.video == video }?.let { Anime ->
                                 Anime.status = AnimeDownload.State.DOWNLOADED
                                 completeAnimeDownload(Anime)
                             }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/AnimeDownloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/AnimeDownloader.kt
@@ -447,7 +447,8 @@ class AnimeDownloader(
                 if (preferences.useExternalDownloader() == download.changeDownloader) {
                     downloadVideo(video, download, tmpDir, filename)
                 } else {
-                    downloadVideoExternal(video, download.source, tmpDir, filename)
+                    val betterFileName = DiskUtil.buildValidFilename("${download.anime.title} - ${download.episode.name}")
+                    downloadVideoExternal(video, download.source, tmpDir, betterFileName)
                 }
             }
         }
@@ -611,18 +612,31 @@ class AnimeDownloader(
                 val intent: Intent
                 if (!pkgName.isNullOrEmpty()) {
                     intent = pm.getLaunchIntentForPackage(pkgName)!!
-                    intent.apply {
-                        // TODO: this only works for 1DM
-                        component = ComponentName(pkgName, "${pkgName.substringBeforeLast(".")}.Downloader")
-                        action = Intent.ACTION_VIEW
-                        data = Uri.parse(video.videoUrl)
-                        putExtra("extra_filename", filename)
+                    when {
+                        pkgName.startsWith("idm.internet.download.manager") -> {
+                            intent.apply {
+                                // TODO: this only works for 1DM
+                                component = ComponentName(pkgName, "${pkgName.substringBeforeLast(".")}.Downloader")
+                                action = Intent.ACTION_VIEW
+                                data = Uri.parse(video.videoUrl)
+                                putExtra("extra_filename", filename)
+                            }
+                        }
+                        pkgName.startsWith("com.dv.adm") -> {
+                            it.delete()
+                            intent.apply {
+                                component = ComponentName(pkgName, "$pkgName.AEditor")
+                                action = Intent.ACTION_VIEW
+                                putExtra("com.dv.get.ACTION_LIST_ADD", "${Uri.parse(video.videoUrl)}<info>$filename.mp4")
+                                putExtra("com.dv.get.ACTION_LIST_PATH", tmpDir.filePath!!.substringBeforeLast("_"))
+                            }
+                        }
                     }
                 } else {
                     intent = Intent(Intent.ACTION_VIEW)
                     intent.apply {
                         addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                        data = Uri.parse(video.videoUrl)
+                        setDataAndType(Uri.parse(video.videoUrl), "video/*")
                         putExtra("extra_filename", filename)
                     }
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -36,7 +36,8 @@ class PreferencesHelper(val context: Context) {
     private val flowPrefs = FlowSharedPreferences(prefs)
 
     private val defaultDownloadsDir = File(
-        Environment.getExternalStorageDirectory().absolutePath + File.separator +
+        Environment.getExternalStorageDirectory().absolutePath + File.separator
+            + Environment.DIRECTORY_DOWNLOADS + File.separator +
             context.getString(R.string.app_name),
         "downloads",
     ).toUri()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -36,8 +36,8 @@ class PreferencesHelper(val context: Context) {
     private val flowPrefs = FlowSharedPreferences(prefs)
 
     private val defaultDownloadsDir = File(
-        Environment.getExternalStorageDirectory().absolutePath + File.separator
-            + Environment.DIRECTORY_DOWNLOADS + File.separator +
+        Environment.getExternalStorageDirectory().absolutePath + File.separator +
+            Environment.DIRECTORY_DOWNLOADS + File.separator +
             context.getString(R.string.app_name),
         "downloads",
     ).toUri()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
@@ -265,6 +265,7 @@ class SettingsDownloadController : SettingsController() {
                         "idm.internet.download.manager" -> true
                         "idm.internet.download.manager.plus" -> true
                         "idm.internet.download.manager.lite" -> true
+                        "com.dv.adm" -> true
                         else -> false
                     }
                 }
@@ -342,6 +343,7 @@ class SettingsDownloadController : SettingsController() {
 
         private fun getDefaultDownloadDir(): File {
             val defaultDir = Environment.getExternalStorageDirectory().absolutePath +
+                File.separator + Environment.DIRECTORY_DOWNLOADS +
                 File.separator + resources?.getString(R.string.app_name) +
                 File.separator + "downloads"
 


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->


https://user-images.githubusercontent.com/80992641/194728375-a9c2b45b-9a33-4124-9cdf-c38fe6201ff9.mp4

I changed the default download directory from: "/Aniyomi/downloads" to "/Downloads/Aniyomi/" because ADM can only download to the "downloads" and "documents" folders.
without this change ADM would give an error saying that you do not have access to the directory