### PR TITLE
Re add alt download option (Fix 1)

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/components/EpisodeDownloadIndicator.kt
+++ b/app/src/main/java/eu/kanade/presentation/components/EpisodeDownloadIndicator.kt
@@ -54,7 +54,7 @@ fun EpisodeDownloadIndicator(
                     val episodeDownloadAction = when {
                         isDownloaded -> EpisodeDownloadAction.DELETE
                         isDownloading -> EpisodeDownloadAction.CANCEL
-                        else -> EpisodeDownloadAction.START_NOW
+                        else -> EpisodeDownloadAction.START_ALT
                     }
                     onClick(episodeDownloadAction)
                 },


### PR DESCRIPTION
Changes 
---

- Automatically downloads alternatively upon holding the option

Pick between Fix 1 and 2.

Fix 1 has only a hold

Fix 2 has a hold + dropdown box click