### PR TITLE
Fix vlc not launching on api 33

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/ExternalIntents.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/ExternalIntents.kt
@@ -132,7 +132,11 @@ class ExternalIntents(val anime: Anime, val source: AnimeSource) {
         }
         return Intent(Intent.ACTION_VIEW).apply {
             if (isPackageInstalled(pkgName, context.packageManager)) {
-                component = getComponent(pkgName)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && pkgName.contains("vlc")) {
+                    setPackage(pkgName)
+                } else {
+                    component = getComponent(pkgName)
+                }
             }
             setDataAndType(uri, "video/*")
             flags = Intent.FLAG_GRANT_READ_URI_PERMISSION


### PR DESCRIPTION
This will let let aniyomi launch vlc on android 13 but watch state is not saved becasue of an issue in vlc. 
It is already fixed by this [commit](https://code.videolan.org/videolan/vlc-android/-/commit/fad03ab5feec9a33bc4f32ea43f865eb60aa159c) and should start saving watched state starting from the next vlc update. hopefully :)
