### PR TITLE
Aniskip: Show other types even if intro is not detected

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -1518,9 +1518,8 @@ class PlayerActivity :
 
     private fun aniSkipStuff(value: Long) {
         if (aniSkipEnable) {
-            // if it doesn't find the opening it will show the +85 button
-            val showNormalSkipButton = aniSkipInterval?.firstOrNull { it.skipType == SkipType.OP || it.skipType == SkipType.MIXED_OP } == null
-            if (showNormalSkipButton) return
+            // if it doesn't find any interval it will show the +85 button
+            if (aniSkipInterval == null) return
 
             skipType = aniSkipInterval?.firstOrNull { it.interval.startTime <= value && it.interval.endTime > value }?.skipType
             skipType?.let { skipType ->
@@ -1539,7 +1538,7 @@ class PlayerActivity :
                 }
             } ?: run {
                 launchUI {
-                    playerControls.binding.controlsSkipIntroBtn.isVisible = false
+                    playerControls.binding.controlsSkipIntroBtn.text = getString(R.string.player_controls_skip_intro_text, presenter.getAnimeSkipIntroLength())
                 }
             }
         }


### PR DESCRIPTION
Currently if aniskip doesn't provides intro, but provides other types such as recap, aniyomi will just ignore all the other types. With this pull request, it will show the appropriate skip type whenever it appears and show the +85 second button otherwise.
