### PR TITLE
Fixed Automatic Episode Deletion

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
@@ -178,6 +178,10 @@ class PlayerViewModel(
                 downloadManager.addDownloadsToStartOfQueue(listOf(it))
             }
         }
+        val currentEpisode = currentEpisode ?: return
+        if (currentEpisode.seen) {
+            deletePendingEpisodes()
+        }
     }
 
     /**
@@ -593,9 +597,7 @@ class PlayerViewModel(
      * are ignored.
      */
     fun deletePendingEpisodes() {
-        viewModelScope.launchNonCancellable {
-            downloadManager.deletePendingEpisodes()
-        }
+        downloadManager.deletePendingEpisodes()
     }
 
     /**


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
I've made it so that when the episode is seen and the video player is cleared, and episodes pending deletion is called, and also removed the coroutineScope due to it not working when it's there. (Note: I know little about coroutineScope, and I am unaware how important it is/if there is a replace in this scenario for it